### PR TITLE
Skip writing the response to cache if the graphql response returns an error

### DIFF
--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -90,6 +90,18 @@ describe('offline network interface', () => {
     expect(mockNetworkInterface.query).toHaveBeenCalledTimes(1);
     jest.clearAllMocks();
 
+    // Test server error handling (optimistic query response)
+    const errorResponse = { errors: ['error'], data: {} };
+    (mockNetworkInterface.query as any).mockImplementation(() => Promise.resolve(errorResponse));
+
+    expect(((await networkInterface.setClient(client).query(request2)) as any).data)
+      .toBe(response3);
+    expect(client.readQuery).toHaveBeenCalledTimes(1);
+    expect(client.writeQuery).toHaveBeenCalledTimes(0);
+    expect(mockNetworkInterface.query).toHaveBeenCalledTimes(1);
+    jest.clearAllMocks();
+    (mockNetworkInterface.query as any).mockImplementation(() => Promise.resolve(response));
+
     // Test fallback when reading query from cache fails
     (client.readQuery as any).mockImplementation(() => { throw new Error(); });
     (client.writeQuery as any).mockReset();

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -42,8 +42,8 @@ export default class OfflineNetworkInterface implements NetworkInterface {
             resolve({ data: this.client.readQuery(request as any) });
 
             // Queue fetch network request
-            this.networkInterface.query(request).then(({ data }) =>
-              this.client && this.client.writeQuery({ ...(request as any), data }),
+            this.networkInterface.query(request).then(({ data, errors }) =>
+              this.client && !errors && this.client.writeQuery({ ...(request as any), data }),
             ).catch(() => {/* ignore */});
 
             return;


### PR DESCRIPTION
>Previously if there was data in the cache but the request started returning an error, the new response would be written to the cache with an empty `data` object, essentially wiping out the good data. The standard Apollo behavior is to skip writing the data to the cache on an error, leaving the good data there to be rendered. This commit preserves that same behavior for optimistic fetch.

Thanks for writing this package @MLPXBrachmann! I was halfway through adding offline support for Lola's RN app using `redux-persist` when we came across this package which was a bit cleaner and seamless to integrate. 